### PR TITLE
fix for the issue with scrolling in the book vieweng UI

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,11 @@ mkcert -install -cert-file ./traefik/tls/cert.pem -key-file ./traefik/tls/key.pe
 
 ### Step 3: Start the Containers
 
+- Create the network for traefik
+```shell
+docker network create traefik-network
+```
+
 - Build the images and start the containers with:
 
 ```shell

--- a/frontend/src/components/Book.vue
+++ b/frontend/src/components/Book.vue
@@ -10,9 +10,10 @@
         </div>
 
         <Swiper
+            @swiper="onSwiper"
             @key-press="closeOnEsc"
             :modules="[ Pagination, EffectCreative, Keyboard, Mousewheel ]"
-            :mousewheel="true"
+            :mousewheel="false"
             :effect="'creative'"
             :keyboard="{ enabled: true, onlyInViewport: false }"
             :creative-effect="creativeEffect"
@@ -40,8 +41,8 @@
 
     import { Swiper, SwiperSlide } from 'swiper/vue'
     import { Pagination, EffectCreative, Keyboard, Mousewheel } from 'swiper/modules'
-    import { CreativeEffectOptions, Swiper as SwiperType } from 'swiper/types'
-    import { X } from 'lucide-vue-next'
+    import { CreativeEffectOptions, type Swiper as SwiperClass, Swiper as SwiperType } from 'swiper/types'
+    import { onMounted, onUnmounted, ref } from "vue";    import { X } from 'lucide-vue-next'
     import Slide1 from './Slide1.vue'
     import Intro from './Intro.vue'
 
@@ -52,8 +53,13 @@
     import { BookDetailResource } from '../api.ts'
 
     const emit = defineEmits([ 'close' ])
+    const swiperInstanceRef = ref<SwiperClass>()
 
-    function closeOnEsc(swiper: SwiperType, keyCode: string): void {
+    function onSwiper(swiper: SwiperClass) {
+      swiperInstanceRef.value = swiper
+    }
+
+    function closeOnEsc(_: SwiperType, keyCode: string): void {
         if (parseInt(keyCode) === 27) {
             emit('close')
         }
@@ -75,6 +81,37 @@
             rotate: [ -60, 0, -20 ],
         },
     }
+
+    const isScrollingRef = ref<boolean>(false)
+    const scrollStopDelayRef = ref<NodeJS.Timeout | null>(null)
+    const onMouseWheel = (event: WheelEvent) => {
+      if (!swiperInstanceRef.value) return
+
+      if (!isScrollingRef.value) {
+        if (event.deltaY > -0 || event.deltaX > -0) {
+          swiperInstanceRef.value?.slideNext();
+        } else if (event.deltaY < 0 || event.deltaX < 0) {
+          swiperInstanceRef.value?.slidePrev();
+        }
+
+        isScrollingRef.value = true;
+      }
+
+      if (scrollStopDelayRef.value) clearTimeout(scrollStopDelayRef.value);
+      scrollStopDelayRef.value = setTimeout(() => {
+        isScrollingRef.value = false;
+      }, 100);
+
+      event.preventDefault()
+    }
+
+    onMounted(() => {
+      window.addEventListener('wheel', onMouseWheel, { passive: false })
+    })
+
+    onUnmounted(() => {
+      window.removeEventListener('wheel', onMouseWheel)
+    })
 
 </script>
 


### PR DESCRIPTION
The problem is that when you scroll (using both the mouse wheel and the touchpad) to turn a page in the book viewing UI, it may flip several pages at once due to scroll inertia, i.e., multiple scroll event triggers. This cannot be resolved using the swiper's API